### PR TITLE
Removing trailing slash to fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Registration-free open source text-based blind review system for
 Accuracy Review of Wikipedias 2016 Google Summer of Code project for
 Wikimedia Foundation.
 
-Please see https://priyankamandikal.github.io/posts/gsoc-2016-project-overview/
+Please see https://priyankamandikal.github.io/posts/gsoc-2016-project-overview
 
 Two initial question datasets are at https://drive.google.com/file/d/0B73LgocyHQnfNlhVQlRIRVFCMVNteldpUFNWbEd4dTZVUjNj/view
 


### PR DESCRIPTION
The link is also broken here: https://techdevguide.withgoogle.com/paths/advanced/sequence-3/wikipedia-accuracy-review if you know who maintains that site or can implement URL redirection to forward the broken link to the working link